### PR TITLE
Updated the print credentials example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $ python3 ./gophish-cli.py campaign --results
 To print credentials
 
 ```
-$ python3 ./gophish-cli.py campaign --print-creds
+$ python3 ./gophish-cli.py creds --print
 +---------------------+--------------+------------+
 | Email               | User         | Pass       |
 +---------------------+--------------+------------+


### PR DESCRIPTION
The old command showed in the README.md didn't work, I just updated the README to fit the real syntax required to print credentials.